### PR TITLE
unused import deleted

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,5 @@
 <script>
 	import Board from '../lib/Board.svelte';
-	import Coin from '../lib/Coin.svelte';
 </script>
 
 <header>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [x] Refactor
- [ ] Optimization

## Description

Unused import Coin in src\routes\+page.svelte deleted.
This specific warning did not show when I ran npm run lint

## Related Tickets & Documents

- Related Issue #73
- Closes #73

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: tested running npm run lint
- [ ] I need help with writing tests


