### PR TITLE
ignored dist/ dir for build config

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -12,3 +12,4 @@ pnpm-lock.yaml
 package-lock.json
 yarn.lock
 /coverage
+/dist

--- a/.prettierignore
+++ b/.prettierignore
@@ -16,3 +16,4 @@ yarn.lock
 /.github
 /.netlify
 /.vscode
+/dist


### PR DESCRIPTION
- [ ✅] Feature

- .eslintignore config to ignore dist/ during build process
- .prettierignore config to ignore dist/ during build process 